### PR TITLE
Add null digest short circuit to Event Pwave metric

### DIFF
--- a/src/main/java/asl/seedscan/metrics/EventComparePWaveOrientation.java
+++ b/src/main/java/asl/seedscan/metrics/EventComparePWaveOrientation.java
@@ -151,6 +151,10 @@ public class EventComparePWaveOrientation extends Metric {
       ByteBuffer digest = metricData.valueDigestChanged(curChannel, createIdentifier(curChannel),
           getForceUpdate());
 
+      if (digest == null) {
+        continue;
+      }
+
       Channel pairChannel = curChannel.getHorizontalOrthogonalChannel();
       Channel vertChannel = chNameMap.get(vertName);
 


### PR DESCRIPTION
I was unable to add a test case due to complications in getting a null digest from metricdata.