### PR TITLE
Pull in preparation of release 1.6.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,8 +19,7 @@ if (file('database.gradle').exists()) {
    apply from:'database.gradle'
 }
 
-
-version = '1.6.2'
+version = '1.6.3'
 
 mainClassName = 'asl.seedscan.SeedScan'
 applicationDefaultJvmArgs = ["-Xms64m", "-Xmx30g"]

--- a/src/main/java/asl/metadata/ChannelData.java
+++ b/src/main/java/asl/metadata/ChannelData.java
@@ -38,32 +38,6 @@ public class ChannelData {
 		return name;
 	}
 
-	// comments
-	LocalDateTime addComment(Blockette blockette)
-			throws MissingBlocketteDataException, TimestampFormatException,
-			WrongBlocketteException {
-		if (blockette.getNumber() != CHANNEL_COMMENT_BLOCKETTE_NUMBER) {
-			throw new WrongBlocketteException();
-		}
-		// Epoch epochNew = new Epoch(blockette);
-		String timestampString = blockette.getFieldValue(3, 0);
-		if (timestampString == null) {
-			throw new MissingBlocketteDataException();
-		}
-		LocalDateTime timestamp = BlocketteTimestamp
-                .parseTimestamp(timestampString);
-		comments.put(timestamp, blockette);
-		return timestamp;
-	}
-
-	public boolean hasComment(LocalDateTime timestamp) {
-		return comments.containsKey(timestamp);
-	}
-
-	public Blockette getComment(LocalDateTime timestamp) {
-		return comments.get(timestamp);
-	}
-
 	// epochs
 	LocalDateTime addEpoch(Blockette blockette)
 			throws MissingBlocketteDataException, TimestampFormatException,

--- a/src/main/java/asl/metadata/Dataless.java
+++ b/src/main/java/asl/metadata/Dataless.java
@@ -78,13 +78,15 @@ class Dataless {
 	private SeedVolume volume;
 	private Collection<String> rawDataless;
 	private ArrayList<Blockette> blockettes;
+	private String networkName;
 	private double percent;
 	private double lastPercent;
 	private double count;
 	private double total;
 	
-	Dataless(Collection<String> rawDataless) {
+	Dataless(Collection<String> rawDataless, String networkName) {
 		this.rawDataless = rawDataless;
+		this.networkName = networkName;
 	}
 
 	void processVolume() throws DatalessParseException {
@@ -208,7 +210,7 @@ class Dataless {
 				if (volume != null) {
 					throw new DuplicateBlocketteException();
 				}
-				volume = new SeedVolume(blockette);
+				volume = new SeedVolume(blockette, networkName);
 				break;
 			case 11:
 				if (volume == null) {
@@ -263,13 +265,6 @@ class Dataless {
 					throw new BlocketteOutOfOrderException();
 				}
 				epoch.setFormat(blockette);
-				break;
-			case 59:
-				if (channel == null) {
-					throw new BlocketteOutOfOrderException();
-				}
-
-				channel.addComment(blockette);
 				break;
 			case 53:
 			case 54:

--- a/src/main/java/asl/metadata/MetaGenerator.java
+++ b/src/main/java/asl/metadata/MetaGenerator.java
@@ -102,6 +102,7 @@ public class MetaGenerator {
 			System.exit(0);
 		}
 		for (String fileName : files) {
+			String networkName = fileName.replace(".dataless","");
 			String datalessFile = dir + "/" + fileName;
 			System.out.format(
 					"== MetaGenerator: rdseed -f [datalessFile=%s]\n",
@@ -137,7 +138,7 @@ public class MetaGenerator {
 
 
 			try {
-				volume = buildVolumesFromStringData(strings);
+				volume = buildVolumesFromStringData(strings, networkName);
 			} catch (Exception e) {
 				logger.error("== processing dataless volume for file=[{}]",	fileName);
 			}
@@ -152,8 +153,8 @@ public class MetaGenerator {
 		} // end for loop over XX.dataless files
 	}
 
-	SeedVolume buildVolumesFromStringData(List<String> strings) throws DatalessParseException {
-		Dataless dataless = new Dataless(strings);
+	SeedVolume buildVolumesFromStringData(List<String> strings, String networkName) throws DatalessParseException {
+		Dataless dataless = new Dataless(strings, networkName);
 		dataless.processVolume();
 		return dataless.getVolume();
 	}

--- a/src/main/java/asl/metadata/SeedVolume.java
+++ b/src/main/java/asl/metadata/SeedVolume.java
@@ -22,7 +22,8 @@ public class SeedVolume {
 	/** The volume info blockette: blockette 10. */
 	private Blockette volumeInfo = null;
 
-	/** The network key. This is based on info blockette field 9: volume label */
+	/** The network key. This is derived from filename (i.e., XX in XX.dataless is network name)
+	 * This used to be derived from info blockette field 9, but this is not necessarily the name. */
 	private NetworkKey networkKey = null;
 
 	/** The station locators. */
@@ -45,13 +46,9 @@ public class SeedVolume {
 	 * @param volumeInfo
 	 *            the volume info
 	 */
-	public SeedVolume(Blockette volumeInfo) {
+	public SeedVolume(Blockette volumeInfo, String networkName) {
 		this.volumeInfo = volumeInfo;
-		try {
-			this.networkKey = new NetworkKey(volumeInfo);
-		} catch (WrongBlocketteException e) {
-			logger.error("== WrongBlocketteException:", e);
-		}
+		this.networkKey = new NetworkKey(networkName); // formerly derived from vol info blockette
 		stations = new Hashtable<>();
 		stationLocators = new ArrayList<>();
 	}

--- a/src/main/java/asl/plotmaker/PlotMaker2.java
+++ b/src/main/java/asl/plotmaker/PlotMaker2.java
@@ -33,6 +33,7 @@ import org.jfree.chart.axis.NumberAxis;
 import org.jfree.chart.axis.NumberTickUnit;
 import org.jfree.chart.plot.CombinedDomainXYPlot;
 import org.jfree.chart.plot.XYPlot;
+import org.jfree.chart.renderer.xy.XYDotRenderer;
 import org.jfree.chart.renderer.xy.XYLineAndShapeRenderer;
 import org.jfree.chart.title.TextTitle;
 import org.jfree.data.Range;
@@ -148,7 +149,7 @@ public class PlotMaker2 {
 			horizontalAxis.setTickLabelFont(fontPlain);
 
 			XYSeriesCollection seriesCollection = new XYSeriesCollection();
-			XYLineAndShapeRenderer renderer = new XYLineAndShapeRenderer();
+			XYDotRenderer renderer = new XYDotRenderer();
 			XYPlot xyplot = new XYPlot(seriesCollection,
 					horizontalAxis, verticalAxis, renderer);
 			xyplot.setDomainGridlinesVisible(true);
@@ -170,8 +171,6 @@ public class PlotMaker2 {
 
 				renderer.setSeriesPaint(iTrace, trace.getColor());
 				renderer.setSeriesStroke(iTrace, trace.getStroke());
-				renderer.setSeriesLinesVisible(iTrace, true);
-				renderer.setSeriesShapesVisible(iTrace, false);
 
 				seriesCollection.addSeries(series);
 

--- a/src/main/java/asl/seedsplitter/SeedSplitProcessor.java
+++ b/src/main/java/asl/seedsplitter/SeedSplitProcessor.java
@@ -37,8 +37,8 @@ public class SeedSplitProcessor implements Runnable {
 	private Hashtable<String, ArrayList<DataSet>> m_table = null;
 
 	// MTH:
-	private Hashtable<String, ArrayList<Integer>> m_qualityTable = null;
-	private Hashtable<String, ArrayList<Blockette320>> m_calTable = null;
+	private Hashtable<String, ArrayList<Integer>> m_qualityTable = new Hashtable<>();
+	private Hashtable<String, ArrayList<Blockette320>> m_calTable = new Hashtable<>();
 
 	private Pattern m_patternNetwork = null;
 	private Pattern m_patternStation = null;
@@ -376,10 +376,6 @@ public class SeedSplitProcessor implements Runnable {
 						// block and store it for this key
 						int quality = record.getTimingQuality();
 
-						if (m_qualityTable == null) {
-							m_qualityTable = new Hashtable<>();
-						}
-
 						ArrayList<Integer> qualityArray = null;
 						if (m_qualityTable.get(key) == null) {
 							qualityArray = new ArrayList<>();
@@ -408,9 +404,6 @@ public class SeedSplitProcessor implements Runnable {
 							// System.out.format("== blockette320: epoch secs=[%d]\n",
 							// blockette320.getCalibrationEpoch() );
 
-							if (m_calTable == null) {
-								m_calTable = new Hashtable<>();
-							}
 
 							ArrayList<Blockette320> calBlock = null;
 							if (m_calTable.get(key) == null) {

--- a/src/test/java/asl/metadata/MetaGeneratorMock.java
+++ b/src/test/java/asl/metadata/MetaGeneratorMock.java
@@ -25,7 +25,7 @@ public class MetaGeneratorMock extends MetaGenerator {
 
 
 
-    public MetaGeneratorMock(String rdseedTextDumpLocation) {
+    public MetaGeneratorMock(String rdseedTextDumpLocation, String networkName) {
 
         List<String> strings = new ArrayList<>();
         BufferedReader reader = null;
@@ -50,7 +50,7 @@ public class MetaGeneratorMock extends MetaGenerator {
         SeedVolume volume = null;
 
         try {
-            volume = buildVolumesFromStringData(strings);
+            volume = buildVolumesFromStringData(strings, networkName);
         } catch (Exception e) {
             logger.error("== processing dataless volume for file=[{}]", rdseedTextDumpLocation);
         }

--- a/src/test/java/asl/seedscan/metrics/EventComparePWaveOrientationTest.java
+++ b/src/test/java/asl/seedscan/metrics/EventComparePWaveOrientationTest.java
@@ -42,15 +42,17 @@ public class EventComparePWaveOrientationTest {
       String metadataLocation4 = "/metadata/rdseed/IU-RAR-ascii-LH.txt";
       String seedDataLocation4 = "/seed_data/IU_RAR/2018/010";
 
-      station = new Station("IU", "ANMO");
-      station3 = new Station("IU", "SSPA");
-      station4 = new Station("IU", "RAR");
+      String networkName = "IU";
+
+      station = new Station(networkName, "ANMO");
+      station3 = new Station(networkName, "SSPA");
+      station4 = new Station(networkName, "RAR");
       dataDate = LocalDate.of(2018, 1, 10);
-      data = ResourceManager.getMetricData(seedDataLocation, metadataLocation, dataDate, station);
+      data = ResourceManager.getMetricData(seedDataLocation, metadataLocation, dataDate, station, networkName);
       data2 = (MetricData) ResourceManager
           .loadCompressedObject("/java_serials/data/IU.TUC.2018.023.ser.gz", true);
-      data3 = ResourceManager.getMetricData(seedDataLocation3, metadataLocation3, dataDate, station3);
-      data4 = ResourceManager.getMetricData(seedDataLocation4, metadataLocation4, dataDate, station4);
+      data3 = ResourceManager.getMetricData(seedDataLocation3, metadataLocation3, dataDate, station3, networkName);
+      data4 = ResourceManager.getMetricData(seedDataLocation4, metadataLocation4, dataDate, station4, networkName);
       eventLoader = new EventLoader(ResourceManager.getDirectoryPath("/event_synthetics"));
     } catch (Exception e) {
       e.printStackTrace();

--- a/src/test/java/asl/seedscan/metrics/InfrasoundMetricTest.java
+++ b/src/test/java/asl/seedscan/metrics/InfrasoundMetricTest.java
@@ -1,6 +1,7 @@
 package asl.seedscan.metrics;
 
 import static org.junit.Assert.assertEquals;
+
 import asl.metadata.Station;
 import asl.testutils.ResourceManager;
 import java.time.LocalDate;
@@ -9,9 +10,9 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-public class PressureMetricTest {
+public class InfrasoundMetricTest {
 
-  private PressureMetric metric;
+  private InfrasoundMetric metric;
   private static MetricData data;
   private static Station station;
   private static LocalDate dataDate;
@@ -20,9 +21,9 @@ public class PressureMetricTest {
   @BeforeClass
   public static void setUpBeforeClass() {
     try {
-      String networkName = "IU";
       String metadataLocation = "/metadata/rdseed/IU-ANMO-ascii.txt";
       String seedDataLocation = "/seed_data/IU_ANMO/2018/121";
+      String networkName = "IU";
       station = new Station(networkName, "ANMO");
       dataDate = LocalDate.of(2018, 5, 1);
       data = ResourceManager.getMetricData(seedDataLocation, metadataLocation, dataDate, station, networkName);
@@ -39,24 +40,23 @@ public class PressureMetricTest {
   }
 
   @Test
-  public void testMetricResultNear1() {
-    metric = new PressureMetric();
+  public void testMetricResultMatchesExpected() {
+    metric = new InfrasoundMetric();
     metric.setData(data);
     HashMap<String, Double> expect = new HashMap<>();
-    expect.put("30,LDO", 0.9934842767063014);
+    expect.put("32,BDF", 0.8217882293173047);
     TestUtils.testMetric(metric, expect);
   }
 
   @Test
   public final void testGetVersion() {
-    metric = new PressureMetric();
+    metric = new InfrasoundMetric();
     assertEquals(1, metric.getVersion());
   }
 
   @Test
   public final void testGetName() {
-    metric = new PressureMetric();
-    assertEquals("PressureMetric", metric.getName());
+    metric = new InfrasoundMetric();
+    assertEquals("InfrasoundMetric", metric.getName());
   }
-
 }

--- a/src/test/java/asl/testutils/ResourceManager.java
+++ b/src/test/java/asl/testutils/ResourceManager.java
@@ -138,11 +138,11 @@ public abstract class ResourceManager { // NO_UCD (test only)
    * @return complete MetricData object for station day.
    */
   public static MetricData getMetricData(String timeSeriesDataLocation, String metadataLocation,
-                                         LocalDate date, Station station) {
+                                         LocalDate date, Station station, String networkName) {
     // TODO: may need additional data for how to load in metadata objects (i.,e., locations)
     // or to construct new metadata objects for specifically test data
     MetricDatabaseMock mockDB = new MetricDatabaseMock();
-    MetaGeneratorMock mockMetadata = new MetaGeneratorMock(metadataLocation);
+    MetaGeneratorMock mockMetadata = new MetaGeneratorMock(metadataLocation, networkName);
     StationMeta stationMeta = mockMetadata.getStationMeta(station, date.atStartOfDay());
 
     File dir = new File(getDirectoryPath(timeSeriesDataLocation));


### PR DESCRIPTION
Support XML-derived metadata and ignore comments, instantiate quality and calib. hashmaps (#37)
Some of the changes below are derived from accidental duplication of commits across pull requests.
The main changes are related to how data is parsed in.


* Refactor p-wave code and tests for use with 30 secs of data

* Increase window length (add 10 second cushion before exp arrival)

* Remove unused variable

* Make sure data is cleared out in P Wave tests

* Add test case for PressureMetric; use stage 0 to match test case

* Add test cases for name and version number of pressure metric

* Replace call to TauP depthCorrect with setSourceDepth

* Very minor formatting change

* Remove use of progress queue; seedsplitter no longer has GUI

* Add travis integration

* Fix typo in travis yml

* Allow test cases to run without database.gradle existing

* Fix missing paranthesis

* Add database config check for liquibase params

* Correct test case to not refer to outdated directory

* Update version number and resource repo

* Add test case for infrasound metric

* Use dots rather than lines in metric result plots

* Revert "Add test case for infrasound metric"

This reverts commit 1de48c42feca9a66bad7b553534c531f544be430.

* Revert "Revert "Add test case for infrasound metric""

This reverts commit cdde81ef601ebd749f6a22688383a8419ef84459.

* Add test case for infrasound metric

* Use dots rather than lines in metric result plots

* Revert "Add test case for infrasound metric"

This reverts commit 1de48c42feca9a66bad7b553534c531f544be430.

* Revert "Revert "Add test case for infrasound metric""

This reverts commit cdde81ef601ebd749f6a22688383a8419ef84459.

* Change network keys to use filename and not blockette volume id

* Remove parsing/storage of comments from metadata structures

* Stop tests breaking -- add network name field in mock classes

* Add try-catch to deal with possible timing quality parse error

* Remove NPE check, instantiate relevant tables on declaration

* Refactor p-wave code and tests for use with 30 secs of data

* Increase window length (add 10 second cushion before exp arrival)

* Remove unused variable

* Make sure data is cleared out in P Wave tests

* Add test case for PressureMetric; use stage 0 to match test case

* Add test cases for name and version number of pressure metric

* Update version number and resource repo

* Add test case for infrasound metric

* Use dots rather than lines in metric result plots

* Revert "Add test case for infrasound metric"

This reverts commit 1de48c42feca9a66bad7b553534c531f544be430.

* Revert "Add test case for infrasound metric"

This reverts commit 1de48c42feca9a66bad7b553534c531f544be430.

* Revert "Revert "Add test case for infrasound metric""

This reverts commit cdde81ef601ebd749f6a22688383a8419ef84459.

* Revert "Revert "Add test case for infrasound metric""

This reverts commit cdde81ef601ebd749f6a22688383a8419ef84459.

* Change network keys to use filename and not blockette volume id

* Remove parsing/storage of comments from metadata structures

* Stop tests breaking -- add network name field in mock classes

* Add try-catch to deal with possible timing quality parse error

* Remove NPE check, instantiate relevant tables on declaration

* Just ignore comments, add as misc blockette w/o useful data

* Remove outdated comments

* Version number increase